### PR TITLE
Remove -Werror in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean
 
-CFLAGS=-O3 -Wall -g -std=gnu99 -DNDEBUG -I./
+CFLAGS=-O3 -Wall -Werror -Wno-unused-function -Wno-unused-result -g -std=gnu99 -DNDEBUG -I./
 HEADERS=src/bfjit.h src/utils.h src/compiler.h src/interpreter.h src/bytecode.h \
 	codegen.inc
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean
 
-CFLAGS=-O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./
+CFLAGS=-O3 -Wall -g -std=gnu99 -DNDEBUG -I./
 HEADERS=src/bfjit.h src/utils.h src/compiler.h src/interpreter.h src/bytecode.h \
 	codegen.inc
 


### PR DESCRIPTION
When building bfjit, the -Werror argument causes problems. Building with GCC 4.7 causes this:

```
ryan@DevPC-LX:~/bfjit$ CC=gcc make -B
lua dynasm/dynasm.lua src/codegen.dasc > codegen.inc
gcc -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/bfjit.c -o bfjit.o
gcc -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/utils.c -o utils.o
gcc -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/driver.c -o driver.o
gcc -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/compiler.c -o compiler.o
gcc -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/interpreter.c -o interpreter.o
src/interpreter.c: In function ‘interpret’:
src/interpreter.c:64:8: error: ignoring return value of ‘scanf’, declared with attribute warn_unused_result [-Werror=unused-result]
cc1: all warnings being treated as errors
make: *** [interpreter.o] Error 1
ryan@DevPC-LX:~/bfjit$ 
```

GCC 4.8 gives the same error:

```
ryan@DevPC-LX:~/bfjit$ CC=gcc-4.8 make -B
lua dynasm/dynasm.lua src/codegen.dasc > codegen.inc
gcc-4.8 -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/bfjit.c -o bfjit.o
gcc-4.8 -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/utils.c -o utils.o
gcc-4.8 -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/driver.c -o driver.o
gcc-4.8 -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/compiler.c -o compiler.o
gcc-4.8 -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/interpreter.c -o interpreter.o
src/interpreter.c: In function ‘interpret’:
src/interpreter.c:64:8: error: ignoring return value of ‘scanf’, declared with attribute warn_unused_result [-Werror=unused-result]
   scanf("%c", &arena[arena_idx]);
        ^
cc1: all warnings being treated as errors
make: *** [interpreter.o] Error 1
ryan@DevPC-LX:~/bfjit$ 
```

And Clang 3.3 just goes crazy:

```
ryan@DevPC-LX:~/bfjit$ CC=clang make -B
lua dynasm/dynasm.lua src/codegen.dasc > codegen.inc
clang -c -O3 -Wall -Werror -g -std=gnu99 -DNDEBUG -I./ src/bfjit.c -o bfjit.o
In file included from src/bfjit.c:3:
src/bytecode.h:68:12: error: unused function 'get_bytecode'
      [-Werror,-Wunused-function]
static int get_bytecode(byte *pc) {
           ^
src/bytecode.h:72:17: error: unused function 'get_payload'
      [-Werror,-Wunused-function]
static uint32_t get_payload(byte *pc, int payload_index) {
                ^
src/bytecode.h:77:12: error: unused function 'get_total_length'
      [-Werror,-Wunused-function]
static int get_total_length(int bc) {
           ^
3 errors generated.
make: *** [bfjit.o] Error 1
```
